### PR TITLE
Fixed small typo in `make proto`command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ You also need to install [the protoc tool](http://google.github.io/proto-lens/in
 After that you can run:
 
 ```bash
-make protoc
+make proto
 ```


### PR DESCRIPTION
For the proto target, brew install protobuf is not enough (I'm using mac os x); I needed to get additional plugins as well: 

go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
go get -u google.golang.org/grpc
go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway